### PR TITLE
docs: write README + CLAUDE.md conventions (plus ship-skill summary)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -36,6 +36,22 @@ The local quality gate — run it before committing; it replaces git hooks. Pure
    - Subject in the imperative ("add", not "added").
    - **No AI attribution** — no `Co-Authored-By` trailers, no "Generated with…" lines; keep messages factual.
 
+4. Print a one-block summary so the result is scannable at a glance:
+
+   ```
+   ## Shipped
+   - Commit:    <type>: <subject> (<short-sha>)
+   - Files:     <N> changed (+<added>/-<removed>)
+   - Format:    pass
+   - Lint:      pass
+   - Typecheck: pass
+   - Tests:     <passed>/<total> · coverage <stmts>%
+   - Build:     pass
+   - Caveats:   <known issues, or "none">
+   ```
+
+   Report what actually happened — if the gate stopped red, say which step failed and skip the commit; never print `pass` for a step that didn't run.
+
 ## Notes
 
 - Don't push here — use the `open-pr` skill to branch, push, and open the PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,39 @@
 @AGENTS.md
+
+# Project conventions — `<girlsam />`
+
+Personal portfolio site for Sam Goldsmith. Professional but playful; clean, fast, accessible.
+
+## Stack
+
+- Next.js 16 (App Router) · React 19 · TypeScript (strict) · Tailwind CSS v4
+- Tests: Vitest + React Testing Library + jest-axe (jsdom)
+- Deploy: Vercel (later)
+
+## Working agreements
+
+- **Server Components by default.** Add `"use client"` only when a component needs interactivity or browser APIs.
+- **All editable content lives in `lib/content.ts`** (name, roles, work history, tech, copy, links) — edit there, not inside components.
+- **Style with Tailwind tokens** (design tokens in `app/globals.css`); no magic color/spacing values.
+- **Accessibility is a feature:** semantic HTML, keyboard operable, visible focus, `prefers-reduced-motion`, WCAG AA contrast in both themes. Every component test asserts `checkA11y`.
+- **Performance (FAST AF):** minimal client JS, static by default, SVG-first visuals, self-hosted fonts.
+- **Privacy:** never put personal info (email/phone) or a photo of Sam in markup, metadata, or OG images. Contact is a form + social links only.
+
+## Scripts
+
+`dev`, `build`, `start`, `lint`, `lint:fix`, `format`, `format:check`, `typecheck`, `test`, `test:watch`, `test:coverage`.
+
+## Workflow (no git hooks)
+
+Use the committed skills in `.claude/skills/`:
+
+- **ship** — quality gate (format → lint → typecheck → test + coverage → build), then an atomic Conventional Commit. Run before every commit.
+- **open-pr** — branch + ship + push, then `gh pr create` (supports `--draft` / `--reviewer`).
+- **pr-review** — review a PR or branch diff for correctness, a11y, perf, conventions.
+- **write-tests** — behavior-as-spec tests; assert on visible outcomes, not internals.
+
+Conventions: atomic Conventional Commits, **no AI attribution** (no `Co-Authored-By`, no "Generated with…"), squash-merge, one concern per PR.
+
+## Deferred (added in the hardening pass)
+
+GitHub Actions CI, Lighthouse budgets, Playwright e2e.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,55 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# `<girlsam />`
 
-## Getting Started
+Sam Goldsmith's personal site — a clean, fast, accessible corner of the internet. Frontend / full-stack engineer with a humanities background; this repo is meant to be as much a portfolio piece as the site itself.
 
-First, run the development server:
+> Built in the open. The code aims to reflect how I work: small components, strong accessibility, behavior-driven tests, and an AI-assisted, hook-free workflow.
+
+## Stack
+
+- **Next.js 16** (App Router) · **React 19** · **TypeScript** (strict)
+- **Tailwind CSS v4**
+- **Vitest** + **React Testing Library** + **jest-axe**
+- Deployed on **Vercel** (soon)
+
+## Getting started
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+npm run dev      # http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Scripts
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+| Script                                          | What it does             |
+| ----------------------------------------------- | ------------------------ |
+| `npm run dev`                                   | Start the dev server     |
+| `npm run build` / `npm start`                   | Production build / serve |
+| `npm run lint` / `lint:fix`                     | ESLint (+ `jsx-a11y`)    |
+| `npm run format` / `format:check`               | Prettier write / check   |
+| `npm run typecheck`                             | `tsc --noEmit`           |
+| `npm run test` / `test:watch` / `test:coverage` | Vitest (unit + a11y)     |
 
-## Learn More
+## Quality & workflow
 
-To learn more about Next.js, take a look at the following resources:
+No git hooks — the quality gate runs through committed Claude skills in [`.claude/skills/`](.claude/skills):
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- **ship** — format → lint → typecheck → tests + coverage → build, then an atomic commit.
+- **open-pr** — branch, ship, push, and open a PR with `gh`.
+- **pr-review** — review a diff for correctness, accessibility, performance, and conventions.
+- **write-tests** — behavior-as-spec tests (assert on visible outcomes, not internals).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Commits follow [Conventional Commits](https://www.conventionalcommits.org); PRs are squash-merged, one concern each.
 
-## Deploy on Vercel
+## Accessibility & performance
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Accessibility is a first-class requirement: semantic HTML, full keyboard support, visible focus, `prefers-reduced-motion`, and WCAG AA contrast in both light and dark themes. The site targets a near-instant load — minimal client JS, static rendering by default, SVG-first visuals, and self-hosted fonts.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Project structure
+
+```
+app/         # routes, layout, global styles + design tokens
+components/  # UI, Server Components by default (added as the site grows)
+lib/         # content.ts — all editable copy/data — plus helpers
+test/        # test helpers (a11y)
+.claude/     # committed dev-workflow skills
+```


### PR DESCRIPTION
## Summary

Replace the leftover `create-next-app` README with a real project README, expand `CLAUDE.md` from a bare `@AGENTS.md` include into full project conventions, and make the `ship` skill print a scannable summary after it commits.

## What changed

- **`README.md`** — portfolio-oriented overview: stack, getting started, scripts table, the hook-free Claude-skill workflow, accessibility/performance stance, and project structure.
- **`CLAUDE.md`** — full conventions: stack, working agreements (Server Components default, content in `lib/content.ts`, Tailwind tokens, a11y, perf, privacy), scripts, and the no-git-hooks skill workflow.
- **`.claude/skills/ship/SKILL.md`** — adds a final `## Shipped` summary block (commit, files changed, per-step gate results, caveats) so a ship run is legible at a glance.

Two atomic commits: `docs:` (README + CLAUDE.md) and `chore:` (ship-skill summary).

## Testing

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 2/2 passing, 100%
- [x] `npm run build`

## Accessibility

No markup changes — docs and tooling only. jest-axe suite still passing.

## Screenshots

N/A — no UI changes.
