### PR TITLE
feat: hero + experience sections (light baseline)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
-import { SkipLink } from "@/components/SkipLink/SkipLink";
+
 import { BubbleNav } from "@/components/nav/BubbleNav/BubbleNav";
+import { SkipLink } from "@/components/SkipLink/SkipLink";
 import { site } from "@/lib/content";
 import "./globals.css";
 

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import Home from "./page";
 import { checkA11y } from "@/test/a11y";
 
+import Home from "./page";
+
 describe("Home page", () => {
-  it("renders the hero", () => {
+  it("renders the hero and experience sections", () => {
     render(<Home />);
     expect(screen.getByRole("heading", { level: 1, name: /sam goldsmith/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /experience/i })).toBeInTheDocument();
   });
 
   it("has no accessibility violations", async () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { checkA11y } from "@/test/a11y";
 
 import Home from "./page";
+import { checkA11y } from "@/test/a11y";
 
 describe("Home page", () => {
   it("renders the hero and experience sections", () => {

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -3,9 +3,9 @@ import Home from "./page";
 import { checkA11y } from "@/test/a11y";
 
 describe("Home page", () => {
-  it("renders its content", () => {
+  it("renders the hero", () => {
     render(<Home />);
-    expect(screen.getByText(/hello world/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /sam goldsmith/i })).toBeInTheDocument();
   });
 
   it("has no accessibility violations", async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
-import { Hero } from "@/components/sections/Hero/Hero";
 import { Experience } from "@/components/sections/Experience/Experience";
+import { Hero } from "@/components/sections/Hero/Hero";
 
 export default function Home() {
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,11 @@
 import { Hero } from "@/components/sections/Hero/Hero";
+import { Experience } from "@/components/sections/Experience/Experience";
 
 export default function Home() {
-  return <Hero />;
+  return (
+    <>
+      <Hero />
+      <Experience />
+    </>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
+import { Hero } from "@/components/sections/Hero/Hero";
+
 export default function Home() {
-  return (
-    <main>
-      <div>Hello world!</div>
-    </main>
-  );
+  return <Hero />;
 }

--- a/components/SkipLink/SkipLink.test.tsx
+++ b/components/SkipLink/SkipLink.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import { SkipLink } from "./SkipLink";
 import { checkA11y } from "@/test/a11y";
 

--- a/components/nav/BubbleNav/BubbleNav.test.tsx
+++ b/components/nav/BubbleNav/BubbleNav.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import { BubbleNav } from "./BubbleNav";
 import { nav, social } from "@/lib/content";
 import { checkA11y } from "@/test/a11y";

--- a/components/nav/BubbleNav/BubbleNav.tsx
+++ b/components/nav/BubbleNav/BubbleNav.tsx
@@ -28,24 +28,26 @@ export function BubbleNav() {
           ))}
         </ul>
         <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
-        <a
-          href={social.github}
-          aria-label="GitHub"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="rounded-full p-2 text-muted transition-colors hover:text-foreground"
-        >
-          <GitHubIcon />
-        </a>
-        <a
-          href={social.linkedin}
-          aria-label="LinkedIn"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="rounded-full p-2 text-muted transition-colors hover:text-foreground"
-        >
-          <LinkedInIcon />
-        </a>
+        <div className="flex items-center gap-0.5 pr-1.5">
+          <a
+            href={social.github}
+            aria-label="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-full p-1.5 text-muted transition-colors hover:text-foreground"
+          >
+            <GitHubIcon />
+          </a>
+          <a
+            href={social.linkedin}
+            aria-label="LinkedIn"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-full p-1.5 text-muted transition-colors hover:text-foreground"
+          >
+            <LinkedInIcon />
+          </a>
+        </div>
       </nav>
     </header>
   );

--- a/components/sections/Experience/Experience.test.tsx
+++ b/components/sections/Experience/Experience.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import { experience } from "@/lib/content";
-import { checkA11y } from "@/test/a11y";
 
 import { Experience } from "./Experience";
+import { experience } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
 
 describe("Experience", () => {
   it("renders the section heading", () => {

--- a/components/sections/Experience/Experience.test.tsx
+++ b/components/sections/Experience/Experience.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { experience } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
+
+import { Experience } from "./Experience";
+
+describe("Experience", () => {
+  it("renders the section heading", () => {
+    render(<Experience />);
+    expect(screen.getByRole("heading", { level: 2, name: /experience/i })).toBeInTheDocument();
+  });
+
+  it("renders a card for every job, with its company", () => {
+    render(<Experience />);
+    // one role heading per job (roles may repeat, so assert by count)
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(experience.length);
+    for (const job of experience) {
+      expect(screen.getByText(job.company)).toBeInTheDocument();
+    }
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Experience />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/components/sections/Experience/Experience.tsx
+++ b/components/sections/Experience/Experience.tsx
@@ -1,0 +1,40 @@
+import { experience } from "@/lib/content";
+
+/**
+ * Work-history section: a stack of role cards (role, company, tenure, blurb).
+ * Static server component. Content lives in lib/content.ts.
+ */
+export function Experience() {
+  return (
+    <section
+      id="experience"
+      aria-labelledby="experience-heading"
+      className="mx-auto max-w-3xl px-6 py-24"
+    >
+      <h2
+        id="experience-heading"
+        className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl"
+      >
+        Experience
+      </h2>
+
+      <ol className="mt-10 flex flex-col gap-4">
+        {experience.map((job) => (
+          <li
+            key={`${job.company}-${job.start}`}
+            className="rounded-xl border border-border bg-surface/50 p-6"
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+              <h3 className="text-lg font-medium text-foreground">{job.role}</h3>
+              <span className="font-mono text-sm text-muted">
+                {job.start} – {job.end}
+              </span>
+            </div>
+            <p className="mt-1 font-medium text-accent">{job.company}</p>
+            <p className="mt-3 text-muted">{job.blurb}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/components/sections/Hero/Hero.test.tsx
+++ b/components/sections/Hero/Hero.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { Hero } from "./Hero";
+import { hero } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
+
+describe("Hero", () => {
+  it("leads with the greeting as the page heading", () => {
+    render(<Hero />);
+    expect(screen.getByRole("heading", { level: 1, name: /sam goldsmith/i })).toBeInTheDocument();
+  });
+
+  it("lists each role", () => {
+    render(<Hero />);
+    for (const role of hero.roles) {
+      expect(screen.getByText(new RegExp(role, "i"))).toBeInTheDocument();
+    }
+  });
+
+  it("has an Explore call-to-action linking to Experience", () => {
+    render(<Hero />);
+    expect(screen.getByRole("link", { name: /explore/i })).toHaveAttribute("href", "#experience");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Hero />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/components/sections/Hero/Hero.test.tsx
+++ b/components/sections/Hero/Hero.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+
 import { Hero } from "./Hero";
 import { hero } from "@/lib/content";
 import { checkA11y } from "@/test/a11y";

--- a/components/sections/Hero/Hero.tsx
+++ b/components/sections/Hero/Hero.tsx
@@ -1,0 +1,49 @@
+import { hero, site } from "@/lib/content";
+
+/**
+ * Landing hero: brand mark, greeting, the role line (static for now —
+ * rotation is a later pizazz pass), a welcome line, and an Explore CTA that
+ * scrolls to Experience. Static server component.
+ */
+export function Hero() {
+  return (
+    <section
+      id="home"
+      aria-labelledby="hero-heading"
+      className="mx-auto flex min-h-[80svh] max-w-3xl flex-col items-center justify-center px-6 py-24 text-center"
+    >
+      <p className="font-mono text-sm text-accent sm:text-base">{site.brand}</p>
+
+      <h1
+        id="hero-heading"
+        className="mt-6 text-4xl font-semibold tracking-tight text-balance text-foreground sm:text-6xl"
+      >
+        {hero.greeting}
+      </h1>
+
+      <p className="mt-5 font-mono text-base text-muted sm:text-lg">{hero.roles.join("  ·  ")}</p>
+
+      <p className="mt-6 text-lg text-balance text-muted sm:text-xl">{hero.welcome}</p>
+
+      <a
+        href={hero.cta.href}
+        className="mt-12 inline-flex items-center gap-2 rounded-full bg-accent px-6 py-3 font-medium text-accent-foreground transition-opacity hover:opacity-90"
+      >
+        {hero.cta.label}
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 5v14M5 12l7 7 7-7" />
+        </svg>
+      </a>
+    </section>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,8 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
-import jsxA11y from "eslint-plugin-jsx-a11y";
 import prettier from "eslint-config-prettier";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -14,6 +14,28 @@ const eslintConfig = defineConfig([
   {
     rules: {
       ...jsxA11y.flatConfigs.recommended.rules,
+    },
+  },
+  // Import ordering: third-party/package imports in the first block, local
+  // imports (`@/…` and relative) in the next — each block alphabetized, with a
+  // blank line between. Autofixable.
+  {
+    rules: {
+      "import/order": [
+        "error",
+        {
+          // Two blocks only: packages, then all local (`@/…` + relative).
+          groups: [["builtin", "external"], "internal"],
+          pathGroups: [
+            { pattern: "@/**", group: "internal" },
+            { pattern: "./**", group: "internal" },
+            { pattern: "../**", group: "internal" },
+          ],
+          pathGroupsExcludedImportTypes: ["builtin", "external"],
+          "newlines-between": "always",
+          alphabetize: { order: "asc", caseInsensitive: true },
+        },
+      ],
     },
   },
   // Disable stylistic rules that conflict with Prettier. Keep last so it wins.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -16,3 +16,16 @@ export const social = {
   github: "https://github.com/girlsam",
   linkedin: "https://www.linkedin.com/in/samgoldsmith",
 } as const;
+
+export const hero = {
+  greeting: "Hi, I'm Sam Goldsmith,",
+  roles: [
+    "Frontend Developer",
+    "Full-Stack Engineer",
+    "Gardener",
+    "Mountain Biker",
+    "National Park Nerd",
+  ],
+  welcome: "Welcome to my little corner of the internet.",
+  cta: { label: "Explore", href: "#experience" },
+} as const;

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -29,3 +29,39 @@ export const hero = {
   welcome: "Welcome to my little corner of the internet.",
   cta: { label: "Explore", href: "#experience" },
 } as const;
+
+// Placeholder work history — replace with real roles.
+export const experience = [
+  {
+    company: "Company 1",
+    role: "Frontend Engineer",
+    start: "Apr 2022",
+    end: "Sept 2025",
+    blurb:
+      "Lead accessibility and design-system work across a multi-product web app, shipping a component library adopted by five teams.",
+  },
+  {
+    company: "Company 2",
+    role: "Full-Stack Engineer",
+    start: "Mar 2022",
+    end: "Nov 2020",
+    blurb:
+      "Built customer-facing features end to end in TypeScript and Ruby, and led a static-first rebuild that cut page load times in half.",
+  },
+  {
+    company: "Company 3",
+    role: "Web Developer",
+    start: "Sept 2019",
+    end: "Nov 2020",
+    blurb:
+      "Delivered responsive marketing sites and internal tools for small-business clients on tight timelines.",
+  },
+  {
+    company: "Company 4",
+    role: "Web Developer",
+    start: "Mar 2017",
+    end: "Sept 2019",
+    blurb:
+      "Delivered responsive marketing sites and internal tools for small-business clients on tight timelines.",
+  },
+] as const;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach, expect } from "vitest";
-import { toHaveNoViolations } from "jest-axe";
 import { cleanup } from "@testing-library/react";
+import { toHaveNoViolations } from "jest-axe";
+import { afterEach, expect } from "vitest";
 
 // Register jest-axe's accessibility matcher on Vitest's expect.
 expect.extend(toHaveNoViolations);


### PR DESCRIPTION
## Summary

Builds out the first content sections of the site — the Hero and a placeholder Experience — on a clean light-mode baseline, plus a nav spacing fix and an import-ordering lint rule. Pizazz (garden, motion, role rotation) is intentionally deferred to a later polish pass.

Four focused commits:

- **`feat: add the hero section`** — `<girlsam />` mark, "Hi, I'm Sam Goldsmith,", a static role line, "Welcome to my little corner of the internet.", and an Explore CTA that scrolls to Experience. Replaces the placeholder home page and removes an erroneous nested `<main>` (the layout already provides the landmark).
- **`fix: balance bubble nav spacing`** — group + tighten the GitHub/LinkedIn icons and match the social cluster's right inset to the brand mark's left inset.
- **`feat: add the experience section`** — work-history cards (role, company, tenure, blurb) from placeholder data in `content.ts`.
- **`chore: enforce import ordering`** — autofixable `import/order` rule: packages first, then local (`@/` + relative), each block alphabetized.

## What changed

- `components/sections/Hero/` and `components/sections/Experience/` (each with co-located tests)
- `lib/content.ts` — `hero` + `experience` placeholder content
- `app/page.tsx` — composes Hero + Experience; nested `<main>` removed
- `components/nav/BubbleNav/BubbleNav.tsx` — spacing/alignment
- `eslint.config.mjs` — import-ordering rule (applied across the repo)

## Testing

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — 15/15 passing, 100%
- [x] `npm run build`
- [x] `npm run dev` smoke — hero + experience render; one `<main>`; Explore scrolls to `#experience`

## Accessibility

Single `<main>` landmark restored; Hero is a labelled region with the `<h1>`; Experience is a labelled region with an `<h2>` and `<h3>` role headings. jest-axe (`checkA11y`) on Hero, Experience, BubbleNav, SkipLink. Contrast verified manually (jsdom can't).

## Notes / deferred

- Experience companies/roles are placeholders (`Company 1…`) — overwrite in `content.ts`.
- Role rotation, the garden, and motion come in the pizazz pass.

## Screenshots

_Light-mode hero + experience. (Add light screenshots on review.)_
