### PR TITLE
feat: contact section with Formspree form

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -13,11 +13,12 @@ afterEach(() => {
 });
 
 describe("Home page", () => {
-  it("renders the hero, experience, and about sections", () => {
+  it("renders the hero, experience, about, and contact sections", () => {
     render(<Home />);
     expect(screen.getByRole("heading", { level: 1, name: /sam goldsmith/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: /experience/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: /about/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /contact/i })).toBeInTheDocument();
   });
 
   it("has no accessibility violations", async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { About } from "@/components/sections/About/About";
+import { Contact } from "@/components/sections/Contact/Contact";
 import { Experience } from "@/components/sections/Experience/Experience";
 import { Hero } from "@/components/sections/Hero/Hero";
 
@@ -8,6 +9,7 @@ export default function Home() {
       <Hero />
       <Experience />
       <About />
+      <Contact />
     </>
   );
 }

--- a/components/sections/Contact/Contact.test.tsx
+++ b/components/sections/Contact/Contact.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+
+import { Contact } from "./Contact";
+import { social } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
+
+describe("Contact", () => {
+  it("renders the heading and the form fields", () => {
+    render(<Contact />);
+    expect(screen.getByRole("heading", { level: 2, name: /contact/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+  });
+
+  it("links to GitHub and LinkedIn", () => {
+    render(<Contact />);
+    expect(screen.getByRole("link", { name: /github/i })).toHaveAttribute("href", social.github);
+    expect(screen.getByRole("link", { name: /linkedin/i })).toHaveAttribute(
+      "href",
+      social.linkedin,
+    );
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Contact />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/components/sections/Contact/Contact.tsx
+++ b/components/sections/Contact/Contact.tsx
@@ -1,0 +1,51 @@
+import { ContactForm } from "./ContactForm/ContactForm";
+import { GitHubIcon, LinkedInIcon } from "@/components/icons";
+import { contact, social } from "@/lib/content";
+
+/**
+ * Contact section: a short blurb, the Formspree-backed form, and social links.
+ * Static server component wrapping the ContactForm client island.
+ */
+export function Contact() {
+  return (
+    <section
+      id="contact"
+      aria-labelledby="contact-heading"
+      className="mx-auto max-w-3xl px-6 py-24"
+    >
+      <h2
+        id="contact-heading"
+        className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl"
+      >
+        Contact
+      </h2>
+
+      <p className="mt-4 text-lg text-muted">{contact.blurb}</p>
+
+      <div className="mt-8 max-w-md">
+        <ContactForm />
+      </div>
+
+      <div className="mt-8 flex items-center gap-3">
+        <a
+          href={social.github}
+          aria-label="GitHub"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-full border border-border p-2 text-muted transition-colors hover:border-accent hover:text-foreground"
+        >
+          <GitHubIcon />
+        </a>
+        <a
+          href={social.linkedin}
+          aria-label="LinkedIn"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-full border border-border p-2 text-muted transition-colors hover:border-accent hover:text-foreground"
+        >
+          <LinkedInIcon />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/Contact/ContactForm/ContactForm.test.tsx
+++ b/components/sections/Contact/ContactForm/ContactForm.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ContactForm } from "./ContactForm";
+import { contact } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
+
+function fillIn() {
+  fireEvent.change(screen.getByLabelText(/name/i), {
+    target: { value: "Ada" },
+  });
+  fireEvent.change(screen.getByLabelText(/email/i), {
+    target: { value: "ada@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText(/message/i), {
+    target: { value: "Hello there" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ContactForm", () => {
+  it("renders required fields and a submit button", () => {
+    render(<ContactForm />);
+    expect(screen.getByLabelText(/name/i)).toBeRequired();
+    expect(screen.getByLabelText(/email/i)).toHaveAttribute("type", "email");
+    expect(screen.getByLabelText(/message/i)).toBeRequired();
+    expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+  });
+
+  it("shows a success message after a successful submit", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    render(<ContactForm />);
+    fillIn();
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(await screen.findByText(contact.success)).toBeInTheDocument();
+  });
+
+  it("shows an error message when the submit fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    render(<ContactForm />);
+    fillIn();
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(await screen.findByText(contact.error)).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ContactForm />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/components/sections/Contact/ContactForm/ContactForm.tsx
+++ b/components/sections/Contact/ContactForm/ContactForm.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+
+import { contact } from "@/lib/content";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+/**
+ * Accessible contact form that AJAX-POSTs to Formspree (no email exposed in
+ * markup). Honeypot for spam, aria-live status, disabled-while-submitting.
+ */
+export function ContactForm() {
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    setStatus("submitting");
+    try {
+      const res = await fetch(contact.formAction, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new FormData(form),
+      });
+      if (res.ok) {
+        form.reset();
+        setStatus("success");
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <p
+        role="status"
+        className="rounded-xl border border-accent/40 bg-surface/50 p-4 text-foreground"
+      >
+        {contact.success}
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {/* honeypot: real visitors leave this empty */}
+      <input
+        type="text"
+        name="_gotcha"
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        className="hidden"
+      />
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="name" className="text-sm font-medium text-foreground">
+          Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          autoComplete="name"
+          className="rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          className="rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="message" className="text-sm font-medium text-foreground">
+          Message
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          required
+          rows={5}
+          className="resize-y rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="self-start rounded-full bg-accent px-6 py-3 font-medium text-accent-foreground transition-opacity hover:opacity-90 disabled:opacity-60"
+      >
+        {status === "submitting" ? "Sending…" : "Send"}
+      </button>
+
+      <p role="status" aria-live="polite" className="min-h-5 text-sm text-muted">
+        {status === "error" && contact.error}
+      </p>
+    </form>
+  );
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -75,3 +75,10 @@ export const about = {
   inclusive:
     "The internet should be for everyone. Accessibility isn't a box I check at the end — it's the whole point.",
 } as const;
+
+export const contact = {
+  blurb: "Have a project in mind, a question, or just want to say hi? Drop me a line.",
+  formAction: "https://formspree.io/f/xnjyznka",
+  success: "Thanks — your message is on its way. I'll get back to you soon.",
+  error: "Something went wrong. Please try again, or reach me via the links below.",
+} as const;


### PR DESCRIPTION
## Summary

Adds the Contact section: an accessible, Formspree-backed contact form plus social links. No email address is exposed in the markup — contact is form + social only.

## Integration choice

For this Next 16 / React 19 app I used the **dependency-free** approach rather than the `@formspree/react` SDK: a small client component that `fetch`-POSTs `FormData` to the Formspree endpoint with `Accept: application/json`. Keeps the bundle lean (matches the project's minimal-JS ethos) and gives full control over the accessible markup. Easy to swap to `@formspree/react` later if we want field-level `ValidationError`.

## What changed

- `components/sections/Contact/Contact.tsx` (server) — heading, blurb, social links, wraps the form.
- `components/sections/Contact/ContactForm/ContactForm.tsx` (client island) — name/email/message, honeypot (`_gotcha`), `aria-live` status, disabled-while-submitting, success/error states.
- `lib/content.ts` — `contact` (blurb, form endpoint, success/error copy).
- `app/page.tsx` — renders `<Contact />` below About.

## Testing

- [x] `npm run format:check` · `lint` · `typecheck`
- [x] `npm run test:coverage` — 38/38 passing, 93.6% stmts
- [x] `npm run build`
- [x] `npm run dev` smoke — section renders; form posts via fetch (live submit not exercised in CI to avoid emailing)

## Accessibility

Labelled region (`<h2>`); every field has an associated `<label>`; required fields; `aria-live="polite"` status region for errors and a `role="status"` success message; honeypot is `aria-hidden` + `display:none` + `tabindex=-1`; social links have `aria-label`s. jest-axe on Contact + ContactForm.

## Notes

- Form endpoint lives in `content.ts` (Formspree IDs are public — they appear client-side regardless).
