### PR TITLE
feat: site footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 
+import { Footer } from "@/components/Footer/Footer";
 import { BubbleNav } from "@/components/nav/BubbleNav/BubbleNav";
 import { SkipLink } from "@/components/SkipLink/SkipLink";
 import { site } from "@/lib/content";
@@ -34,6 +35,7 @@ export default function RootLayout({
         <SkipLink />
         <BubbleNav />
         <main id="main">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/components/Footer/Footer.test.tsx
+++ b/components/Footer/Footer.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+
+import { Footer } from "./Footer";
+import { social } from "@/lib/content";
+import { checkA11y } from "@/test/a11y";
+
+describe("Footer", () => {
+  it("is a contentinfo landmark", () => {
+    render(<Footer />);
+    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+  });
+
+  it("links to the source repo and socials", () => {
+    render(<Footer />);
+    expect(screen.getByRole("link", { name: /view source/i })).toHaveAttribute("href", social.repo);
+    expect(screen.getByRole("link", { name: /github/i })).toHaveAttribute("href", social.github);
+    expect(screen.getByRole("link", { name: /linkedin/i })).toHaveAttribute(
+      "href",
+      social.linkedin,
+    );
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Footer />);
+    expect(await checkA11y(container)).toHaveNoViolations();
+  });
+});

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,0 +1,46 @@
+import { ArrowUpRightIcon, GitHubIcon, LinkedInIcon } from "@/components/icons";
+import { site, social } from "@/lib/content";
+
+/**
+ * Site footer: brand mark, a "view source" link (the code-as-portfolio
+ * payoff), and social links. Static server component.
+ */
+export function Footer() {
+  return (
+    <footer className="border-t border-border">
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 px-6 py-12 text-sm sm:flex-row sm:justify-between sm:gap-4">
+        <p className="font-mono text-foreground">{site.brand}</p>
+
+        <div className="flex items-center gap-5 text-muted">
+          <a
+            href={social.repo}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+          >
+            View source
+            <ArrowUpRightIcon className="size-3.5" />
+          </a>
+          <a
+            href={social.github}
+            aria-label="GitHub"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            <GitHubIcon className="size-5" />
+          </a>
+          <a
+            href={social.linkedin}
+            aria-label="LinkedIn"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            <LinkedInIcon className="size-5" />
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -15,6 +15,7 @@ export const nav = [
 export const social = {
   github: "https://github.com/girlsam",
   linkedin: "https://www.linkedin.com/in/samgoldsmith",
+  repo: "https://github.com/girlsam/personal-site",
 } as const;
 
 export const hero = {


### PR DESCRIPTION
## Summary

Adds the site footer — the last piece of the section skeleton. Brand mark, a prominent "View source" link to the repo (the code-as-portfolio payoff), and GitHub/LinkedIn links. Rendered after `<main>` in the layout as the `contentinfo` landmark.

## What changed

- `components/Footer/Footer.tsx` (+ test) — server component; responsive (stacks on mobile, row on `sm`).
- `app/layout.tsx` — renders `<Footer />` after `<main>`.
- `lib/content.ts` — adds `social.repo` (the source link target).

## Testing

- [x] `npm run format:check` · `lint` · `typecheck`
- [x] `npm run test:coverage` — 41/41 passing, 93.6% stmts
- [x] `npm run build`
- [x] `npm run dev` smoke — footer renders with the View-source link to the repo

## Accessibility

`<footer>` is the `contentinfo` landmark; social links have `aria-label`s; the View-source arrow is `aria-hidden`. jest-axe on the component.

## Notes

- The "small garden" the footer will eventually carry is deferred to the pizazz pass.
