### PR TITLE
fix: clean, unclipped focus ring on carousel cards

### DIFF
--- a/components/spotify/RecentlyPlayed/RecentlyPlayed.tsx
+++ b/components/spotify/RecentlyPlayed/RecentlyPlayed.tsx
@@ -47,7 +47,7 @@ export function RecentlyPlayed() {
 
   return (
     <div className="w-full max-w-2xl">
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-5 flex items-center justify-between">
         <p className="flex items-center gap-1.5 font-mono text-sm text-muted">
           <SpotifyIcon className="size-4 text-[#1DB954]" />
           On my headphones
@@ -75,7 +75,7 @@ export function RecentlyPlayed() {
       <ul
         ref={scroller}
         aria-label="Recently played tracks"
-        className="flex snap-x snap-mandatory [scrollbar-width:none] gap-3 overflow-x-auto pb-2 [&::-webkit-scrollbar]:hidden"
+        className="-m-2 flex snap-x snap-mandatory scroll-p-2 [scrollbar-width:none] gap-3 overflow-x-auto p-2 [&::-webkit-scrollbar]:hidden"
       >
         {tracks.map((track, i) => (
           <li key={`${track.songUrl}-${i}`} className="w-40 shrink-0 snap-start">
@@ -84,11 +84,11 @@ export function RecentlyPlayed() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label={`${track.title} by ${track.artist}${track.isPlaying ? ", now playing" : ""}`}
-              className="group flex flex-col gap-2"
+              className="group flex flex-col gap-2 focus-visible:outline-none"
             >
               <span
                 aria-hidden="true"
-                className="relative block aspect-square overflow-hidden rounded-xl border border-border bg-surface"
+                className="relative block aspect-square overflow-hidden rounded-xl border border-border bg-surface group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-background"
               >
                 {track.albumImageUrl && (
                   // eslint-disable-next-line @next/next/no-img-element -- dynamic external album art (Spotify CDN)


### PR DESCRIPTION
## Summary

Fixes the focus state on the recently-played carousel cards. Tabbing to a card showed the global focus outline as a sharp rectangle wrapping the whole card (art + text), and once scoped to the art it was getting clipped by the horizontal scroll container.

## What changed

- **Scoped + rounded** — the card link's default outline is removed (`focus-visible:outline-none`); the focus indicator is now a rounded **ring on the album art only** (`group-focus-visible:ring-*`), via an *outset* ring so the cover image can't paint over it (an inset ring was being occluded).
- **No clipping** — a horizontal scroller (`overflow-x-auto`) is forced to clip vertically too, which cut the ring at the top and the start/end edges. The scroll row now has interior padding (`p-2`) for the ring to live in, pulled back with a matching `-m-2` so nothing shifts, plus `scroll-p-2` to keep snap alignment. The header gap is nudged (`mb-5`) to absorb the negative top margin.

## Testing

- [x] `npm run format:check` · `lint` · `typecheck`
- [x] `npm run test:coverage` — 43/43 passing
- [x] `npm run build`
- [x] Manual: keyboard-focus each card (incl. first/last at scroll edges) — ring is fully visible, unclipped.

## Note

The faint corner softness on the ring in **Safari** is a known WebKit `box-shadow` rounded-corner rendering quirk (crisp in Chrome/Firefox) — cosmetic only.
