### PR TITLE
fix: log Spotify route errors instead of swallowing them

### DIFF
--- a/app/api/spotify/route.test.ts
+++ b/app/api/spotify/route.test.ts
@@ -16,7 +16,7 @@ const track = {
 };
 
 afterEach(() => {
-  vi.resetAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("GET /api/spotify", () => {
@@ -39,5 +39,14 @@ describe("GET /api/spotify", () => {
     vi.mocked(getTracks).mockResolvedValue([]);
     const res = await GET();
     expect(res.status).toBe(204);
+  });
+
+  it("logs the error and returns 204 when the request throws", async () => {
+    vi.mocked(isConfigured).mockReturnValue(true);
+    vi.mocked(getTracks).mockRejectedValue(new Error("boom"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await GET();
+    expect(res.status).toBe(204);
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/app/api/spotify/route.ts
+++ b/app/api/spotify/route.ts
@@ -13,7 +13,9 @@ export async function GET() {
         "Cache-Control": "public, s-maxage=30, stale-while-revalidate=60",
       },
     });
-  } catch {
+  } catch (error) {
+    // Server-side log only (Vercel function logs) — never reaches the browser.
+    console.error("Spotify API request failed:", error);
     return new Response(null, { status: 204 });
   }
 }


### PR DESCRIPTION
## Summary

The `/api/spotify` route swallowed every failure as a silent `204`, so a real error (bad/expired token, network issue) was indistinguishable from "nothing playing" — and left nothing in the logs to debug with. Now the catch logs the error.

## What changed

- `app/api/spotify/route.ts` — `catch { … }` → `catch (error) { console.error("Spotify API request failed:", error); … }`. Still returns `204` (graceful degradation unchanged).

## Notes

- **Server-side only.** This runs in the route handler (Node runtime), so it logs to Vercel's function logs / the dev terminal — it **never reaches the browser console**.
- **Quiet in normal operation.** It only fires in the `catch`, on a genuine error — not for the normal empty / not-configured `204` paths.

## Testing

- [x] `format:check` · `lint` · `typecheck`
- [x] `npm run test:coverage` — 44/44; added a test for the error path (route is now fully covered). `console.error` is spied/silenced in that test, so no noisy output.
- [x] `npm run build`

## Context

Pairs with the prod Spotify 204: that was missing `SPOTIFY_*` env vars on Vercel (config, not code). With this logging in place, if it's still 204 after setting the vars + redeploying, Vercel's logs will show exactly why.
