### PR TITLE
fix: bubble nav overflows the viewport on mobile

### DIFF
--- a/components/nav/BubbleNav/BubbleNav.tsx
+++ b/components/nav/BubbleNav/BubbleNav.tsx
@@ -12,7 +12,10 @@ export function BubbleNav() {
         aria-label="Primary"
         className="flex items-center gap-1 rounded-full border border-border bg-surface/80 px-2 py-1 text-sm shadow-sm backdrop-blur"
       >
-        <a href="#home" className="rounded-full px-3 py-1.5 font-mono font-medium text-foreground">
+        <a
+          href="#home"
+          className="hidden rounded-full px-3 py-1.5 font-mono font-medium text-foreground sm:block"
+        >
           {site.brand}
         </a>
         <ul className="flex items-center">
@@ -20,15 +23,15 @@ export function BubbleNav() {
             <li key={item.href}>
               <a
                 href={item.href}
-                className="rounded-full px-3 py-1.5 text-muted transition-colors hover:text-foreground"
+                className="rounded-full px-2.5 py-1.5 text-muted transition-colors hover:text-foreground sm:px-3"
               >
                 {item.label}
               </a>
             </li>
           ))}
         </ul>
-        <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
-        <div className="flex items-center gap-0.5 pr-1.5">
+        <span className="mx-1 hidden h-5 w-px bg-border sm:block" aria-hidden="true" />
+        <div className="hidden items-center gap-0.5 pr-1.5 sm:flex">
           <a
             href={social.github}
             aria-label="GitHub"


### PR DESCRIPTION
## Summary

On mobile the sticky bubble nav was wider than the viewport — the pill (brand mark + four links + divider + two social icons) overflowed both edges, which made the whole page pan horizontally and feel zoomed/shifty.

## What changed

`components/nav/BubbleNav/BubbleNav.tsx` — below the `sm` breakpoint:
- hide the **brand mark** (it's in the hero + footer),
- hide the **divider** and **social icons** (socials are in Contact + the footer),
- keep the four section links, with slightly tighter padding (`px-2.5 sm:px-3`) so they fit down to ~320px.

At `sm`+ the full nav is unchanged.

## Why this fixes the "zoom/shift"

A single element wider than the viewport gives the page horizontal scroll, which mobile browsers expose as the page panning / scaling. Trimming the nav to fit removes the overflow.

## Testing

- [x] `format:check` · `lint` · `typecheck`
- [x] `npm run test:coverage` — green (nav test unchanged: the links are still in the DOM, just CSS-hidden on small screens)
- [x] `npm run build`

## How to verify

Open the dev server in DevTools device mode (or narrow the window to ~375px): the nav should sit fully within the screen with no horizontal scroll, showing just Home · Experience · About · Contact.

## Notes / follow-up

Mobile drops the brand + socials rather than introducing a hamburger menu (keeps it JS-free, matches the simple bubble nav). If you'd later want socials/brand on mobile too, a disclosure/hamburger is the natural upgrade.
